### PR TITLE
Bug fix for AU.

### DIFF
--- a/src/get-fiscal-year.ts
+++ b/src/get-fiscal-year.ts
@@ -234,7 +234,10 @@ export default class GetFiscalYear {
       const breakdown = country
         ? this.getDateBreakdownByCountry(country)
         : this.getDateBreakdownByDate(date);
-      if (this.currentDate.getMonth() + 1 < breakdown.fe.month) {
+      if (
+        this.currentDate.getMonth() + 1 < breakdown.fe.month &&
+        this.currentDate.getDay() + 1 < breakdown.fe.day
+      ) {
         return {
           period: "current",
           fiscalYearStart: this.createISODateString(

--- a/src/get-fiscal-year.ts
+++ b/src/get-fiscal-year.ts
@@ -235,8 +235,8 @@ export default class GetFiscalYear {
         ? this.getDateBreakdownByCountry(country)
         : this.getDateBreakdownByDate(date);
       if (
-        this.currentDate.getMonth() + 1 < breakdown.fe.month &&
-        this.currentDate.getDay() + 1 < breakdown.fe.day
+        this.currentDate.getMonth() + 1 <= breakdown.fe.month &&
+        this.currentDate.getDate() <= breakdown.fe.day
       ) {
         return {
           period: "current",


### PR DESCRIPTION
to fixing the AU finance year, add the day compare as well. 
If the other country follows the same logic. (if not then we might need to add one month for startyear config .
Eg: 01/06/2021 (DD/MM/YYYY), the fiscal year start date should be 01/07/2020 but it returned 01/07/2021. 