### PR TITLE
Don't use Date()'s string parsing

### DIFF
--- a/src/get-fiscal-year.ts
+++ b/src/get-fiscal-year.ts
@@ -166,7 +166,6 @@ export default class GetFiscalYear {
    * This returns the date breakdown as a usable object
    */
   private getDateBreakdownByDate(date: string): DateBreakdown {
-    console.log("getDateBreakdownByDate", date);
     const end = new Date(this.currentDate.getFullYear(), Number(date.split("/")[0]) -1, Number(date.split("/")[1]));
     const start = new Date(
       new Date(this.currentDate.getFullYear(), Number(date.split("/")[0]) -1, Number(date.split("/")[1])).setDate(

--- a/src/get-fiscal-year.ts
+++ b/src/get-fiscal-year.ts
@@ -166,9 +166,10 @@ export default class GetFiscalYear {
    * This returns the date breakdown as a usable object
    */
   private getDateBreakdownByDate(date: string): DateBreakdown {
-    const end = new Date(this.currentDate.getFullYear() + "/" + date);
+    console.log("getDateBreakdownByDate", date);
+    const end = new Date(this.currentDate.getFullYear(), Number(date.split("/")[0]) -1, Number(date.split("/")[1]));
     const start = new Date(
-      new Date(this.currentDate.getFullYear() + "/" + date).setDate(
+      new Date(this.currentDate.getFullYear(), Number(date.split("/")[0]) -1, Number(date.split("/")[1])).setDate(
         end.getDate() + 1
       )
     );
@@ -328,9 +329,9 @@ export default class GetFiscalYear {
     year: number
   ): string {
     return new Date(
-      `${year}/${this.appendLeadingZero(
-        breakdown[period].month
-      )}/${this.appendLeadingZero(breakdown[period].day)}`
+      year,
+      breakdown[period].month -1,
+      breakdown[period].day
     ).toISOString();
   }
 }


### PR DESCRIPTION
As per issue raised the Date constructor and Date.parse don't consistently parse date strings across JS engines and specifically fails badly on the Hermes engine that React Native uses.